### PR TITLE
Rewrite circle plane intersection

### DIFF
--- a/crates/geop-geometry/src/curve_surface_intersection/circle_plane.rs
+++ b/crates/geop-geometry/src/curve_surface_intersection/circle_plane.rs
@@ -1,7 +1,9 @@
 use crate::{
+    curve_curve_intersection::circle_line::{circle_line_intersection, CircleLineIntersection},
     curves::circle::Circle,
     points::point::Point,
-    surfaces::{plane::Plane, SurfaceLike},
+    surface_surface_intersection::plane_plane::{plane_plane_intersection, PlanePlaneIntersection},
+    surfaces::plane::Plane,
 };
 
 pub enum CirclePlaneIntersection {
@@ -11,12 +13,77 @@ pub enum CirclePlaneIntersection {
 }
 
 pub fn circle_plane_intersection(circle: &Circle, plane: &Plane) -> CirclePlaneIntersection {
-    // Check if circle and plane are coplanar
-    if plane.on_surface(circle.basis) {
-        // Check if normals are parallel
-        if circle.normal.is_parallel(plane.normal(plane.basis)) {
+    // First find the plane that contains the circle
+    let plane_circle = Plane::new(
+        circle.basis,
+        circle.radius,
+        circle.normal.cross(circle.radius),
+    );
+
+    // Then find the intersection of the two planes
+    match plane_plane_intersection(&plane, &plane_circle) {
+        PlanePlaneIntersection::Plane(_plane) => {
             return CirclePlaneIntersection::Circle(circle.clone());
         }
+        PlanePlaneIntersection::None => {
+            return CirclePlaneIntersection::None;
+        }
+        PlanePlaneIntersection::Line(line) => {
+            // If the planes intersect in a line, find the intersection of the circle with that line
+            match circle_line_intersection(&circle, &line) {
+                CircleLineIntersection::TwoPoint(p1, p2) => {
+                    return CirclePlaneIntersection::Points(vec![p1, p2]);
+                }
+                CircleLineIntersection::OnePoint(p) => {
+                    return CirclePlaneIntersection::Points(vec![p]);
+                }
+                CircleLineIntersection::None => return CirclePlaneIntersection::None,
+            }
+        }
     }
-    todo!("Implement circle-plane intersection.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_circle_plane_intersection_complete() {
+        // test the case where the circle lies completely on the plane
+        let circle = Circle::new(Point::new(0.5, 0.5, 0.0), Point::new(0.0, 0.0, 1.0), 2.0);
+
+        let plane = Plane::new(
+            Point::new(0.0, 0.0, 0.0),
+            Point::new(0.0, 1.0, 0.0),
+            Point::new(1.0, 0.0, 0.0),
+        );
+
+        match circle_plane_intersection(&circle, &plane) {
+            CirclePlaneIntersection::Circle(circle) => {
+                assert_eq!(circle, circle);
+            }
+            _ => panic!("Intersection should be a circle"),
+        }
+    }
+
+    #[test]
+    fn test_circle_plane_intersection_tangent() {
+        // test the case where the circle is tangent to the plane, so one intersection point
+        let circle = Circle::new(Point::new(0.0, 0.0, -1.0), Point::new(0.0, 1.0, 0.0), 1.0);
+
+        let plane = Plane::new(
+            Point::new(0.0, 0.0, 0.0),
+            Point::new(0.0, 1.0, 0.0),
+            Point::new(1.0, 0.0, 0.0),
+        );
+
+        match circle_plane_intersection(&circle, &plane) {
+            CirclePlaneIntersection::Points(points) => {
+                println!("Points: {:?}", points);
+                assert_eq!(points.len(), 1);
+                assert_eq!(points[0], Point::new(0.0, 0.0, 0.0));
+            }
+            _ => panic!("Intersection should be a single point"),
+        }
+    }
 }

--- a/crates/geop-geometry/src/surface_surface_intersection/plane_plane.rs
+++ b/crates/geop-geometry/src/surface_surface_intersection/plane_plane.rs
@@ -1,6 +1,6 @@
 use crate::{
+    curve_surface_intersection::line_plane::{line_plane_intersection, LinePlaneIntersection},
     curves::line::Line,
-    points::point::Point,
     surfaces::{plane::Plane, SurfaceLike},
 };
 
@@ -13,19 +13,91 @@ pub enum PlanePlaneIntersection {
 pub fn plane_plane_intersection(a: &Plane, b: &Plane) -> PlanePlaneIntersection {
     let n_a = a.normal(a.basis);
     let n_b = b.normal(b.basis);
-    let b_a: Point = a.basis;
-    let b_b: Point = b.basis;
+    let b_b = b.basis;
 
-    let v = n_a.cross(n_b);
-    if v.norm() > crate::EQ_THRESHOLD {
-        let t = (n_a.dot(b_b) - n_a.dot(b_a)) / n_a.dot(v);
-        PlanePlaneIntersection::Line(Line::new(b_a + v * t, v))
-    } else {
-        let n = n_a.dot(b_a - b_b);
-        if n.abs() < crate::EQ_THRESHOLD {
-            PlanePlaneIntersection::Plane(Plane::new(a.basis, a.u_slope, a.v_slope))
+    if a.is_parallel(b) {
+        if a.on_surface(b_b) {
+            PlanePlaneIntersection::Plane(a.clone())
         } else {
             PlanePlaneIntersection::None
+        }
+    } else {
+        let v = n_a.cross(n_b).normalize();
+        let c = Line::new(b_b, v.cross(n_b));
+
+        match line_plane_intersection(&c, &a) {
+            LinePlaneIntersection::Point(p) => {
+                return PlanePlaneIntersection::Line(Line::new(p, v));
+            }
+            _ => panic!("Line plane intersection should return a point!"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::points::point::Point;
+
+    use super::*;
+
+    #[test]
+    fn test_plane_plane_intersection_planes() {
+        // Simplest case where the planes intersect in a line
+        let top = Plane::new(
+            Point::new(0.0, 0.0, 0.0),
+            Point::new(1.0, 0.0, 0.0),
+            Point::new(0.0, 1.0, 0.0),
+        );
+
+        let askew = Plane::new(
+            Point::new(1.0, 1.0, 1.0),
+            Point::new(1.0, 0.0, -0.2),
+            Point::new(0.0, 1.0, 0.0),
+        );
+
+        match plane_plane_intersection(&top, &askew) {
+            PlanePlaneIntersection::Line(line) => {
+                assert_eq!(line.direction, Point::new(0.0, 1.0, 0.0));
+                assert!(top.on_surface(line.basis));
+                assert!(askew.on_surface(line.basis));
+            }
+            _ => panic!("Intersection should be a line"),
+        }
+    }
+
+    #[test]
+    fn test_plane_plane_intersection_lines_degenerate() {
+        // This tests the case where the planes intersect in a line
+        // And the line passes through the basis of one of the planes
+        let plane1 = Plane::new(
+            Point::new(0.0, 0.0, 0.0),
+            Point::new(0.0, 1.0, 0.0),
+            Point::new(1.0, 0.0, 0.0),
+        );
+
+        let plane2 = Plane::new(
+            Point::new(0.0, 0.0, -1.0),
+            Point::new(0.0, 1.0, 0.0),
+            Point::new(0.0, 0.0, 1.0),
+        );
+
+        match plane_plane_intersection(&plane1, &plane2) {
+            PlanePlaneIntersection::Line(line) => {
+                assert_eq!(line.direction, Point::new(0.0, -1.0, 0.0));
+                assert!(plane1.on_surface(line.basis));
+                assert!(plane2.on_surface(line.basis));
+            }
+            _ => panic!("Intersection should be a line"),
+        }
+
+        match plane_plane_intersection(&plane2, &plane1) {
+            PlanePlaneIntersection::Line(line) => {
+                // The direction of this line intersection is the opposite of the one above
+                assert_eq!(line.direction, Point::new(0.0, 1.0, 0.0));
+                assert!(plane1.on_surface(line.basis));
+                assert!(plane2.on_surface(line.basis));
+            }
+            _ => panic!("Intersection should be a line"),
         }
     }
 }

--- a/crates/geop-geometry/src/surfaces/plane.rs
+++ b/crates/geop-geometry/src/surfaces/plane.rs
@@ -57,6 +57,10 @@ impl Plane {
         }
         points
     }
+
+    pub fn is_parallel(&self, other: &Plane) -> bool {
+        self.normal().is_parallel(other.normal())
+    }
 }
 
 impl SurfaceLike for Plane {


### PR DESCRIPTION
This PR builds upon https://github.com/TobiasJacob/geop/pull/7, adding support for `circle_plane_intersection`.

Once that commit is merged, this one will simplify to just a single commit and a single file modified.

part of https://github.com/TobiasJacob/geop/issues/6