### PR TITLE
support circle_circle_intersection when not coplanar

### DIFF
--- a/crates/geop-geometry/src/curve_surface_intersection/circle_plane.rs
+++ b/crates/geop-geometry/src/curve_surface_intersection/circle_plane.rs
@@ -8,7 +8,8 @@ use crate::{
 
 pub enum CirclePlaneIntersection {
     None,
-    Points(Vec<Point>),
+    TwoPoints(Point, Point),
+    OnePoint(Point),
     Circle(Circle),
 }
 
@@ -32,10 +33,10 @@ pub fn circle_plane_intersection(circle: &Circle, plane: &Plane) -> CirclePlaneI
             // If the planes intersect in a line, find the intersection of the circle with that line
             match circle_line_intersection(&circle, &line) {
                 CircleLineIntersection::TwoPoint(p1, p2) => {
-                    return CirclePlaneIntersection::Points(vec![p1, p2]);
+                    return CirclePlaneIntersection::TwoPoints(p1, p2);
                 }
                 CircleLineIntersection::OnePoint(p) => {
-                    return CirclePlaneIntersection::Points(vec![p]);
+                    return CirclePlaneIntersection::OnePoint(p);
                 }
                 CircleLineIntersection::None => return CirclePlaneIntersection::None,
             }
@@ -78,10 +79,8 @@ mod tests {
         );
 
         match circle_plane_intersection(&circle, &plane) {
-            CirclePlaneIntersection::Points(points) => {
-                println!("Points: {:?}", points);
-                assert_eq!(points.len(), 1);
-                assert_eq!(points[0], Point::new(0.0, 0.0, 0.0));
+            CirclePlaneIntersection::OnePoint(point) => {
+                assert_eq!(point, Point::new(0.0, 0.0, 0.0));
             }
             _ => panic!("Intersection should be a single point"),
         }

--- a/crates/geop-geometry/src/curve_surface_intersection/curve_surface.rs
+++ b/crates/geop-geometry/src/curve_surface_intersection/curve_surface.rs
@@ -67,7 +67,10 @@ pub fn curve_surface_intersection(curve: &Curve, surface: &Surface) -> CurveSurf
         Curve::Circle(circle) => match surface {
             Surface::Plane(plane) => match circle_plane_intersection(circle, plane) {
                 CirclePlaneIntersection::None => CurveSurfaceIntersection::None,
-                CirclePlaneIntersection::Points(points) => CurveSurfaceIntersection::Points(points),
+                CirclePlaneIntersection::TwoPoints(p1, p2) => {
+                    CurveSurfaceIntersection::Points(vec![p1, p2])
+                }
+                CirclePlaneIntersection::OnePoint(p) => CurveSurfaceIntersection::Points(vec![p]),
                 CirclePlaneIntersection::Circle(circle) => {
                     CurveSurfaceIntersection::Curve(Curve::Circle(circle))
                 }


### PR DESCRIPTION
also changed an enum to be TwoPoints and OnePoint instead of Points.

this is part of https://github.com/TobiasJacob/geop/issues/6