### PR TITLE
Add shell.nix to get geop-wgpu to work on nixOS

### DIFF
--- a/crates/geop-wgpu/shell.nix
+++ b/crates/geop-wgpu/shell.nix
@@ -1,0 +1,26 @@
+{ pkgs ? import <nixpkgs> {} }:    
+  let
+    libPath = with pkgs; lib.makeLibraryPath [
+      libGL
+      libGLU
+      libxkbcommon
+      wayland
+
+      xorg.libX11
+
+      vulkan-loader
+    ];
+  in {
+    devShell = with pkgs; mkShell {
+      buildInputs = [
+        cargo
+        rustc
+        rust-analyzer
+        pkg-config
+      ];
+      
+      RUST_LOG = "debug";
+      RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+      LD_LIBRARY_PATH = libPath;
+    };
+  }


### PR DESCRIPTION
This is what I needed to get `cargo run` to work for geop-wgpu, thought I would put it somewhere.